### PR TITLE
Move State for Edit Form to BookForm

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,10 +17,9 @@ class App extends React.Component {
       thenBy: "length",
       thenByOrder: "ascending"
     },
-    bookFormContent: {},
+    selectedBook: {},
     showEditForm: false,
     adminMode: false,
-    editing: false,
     isbnCollision: false
   };
 
@@ -57,8 +56,8 @@ class App extends React.Component {
     if (value) {
       filters.push(name);
     } else {
-      const deleteMe = filters.indexOf(name);
-      if (deleteMe >= 0) filters.splice(deleteMe, 1);
+      const i = filters.indexOf(name);
+      if (i >= 0) filters.splice(i, 1);
     }
     this.setState({ filters });
   };
@@ -70,51 +69,34 @@ class App extends React.Component {
   };
 
   createNewBook = () => {
-    this.setState({ bookFormContent: {} });
-    this.setState({ editing: false });
+    this.setState({ selectedBook: {} });
     this.setState({ showEditForm: true });
   };
 
   loadBook = isbn => {
     const books = this.state.books;
-    const bookFormContent = books.find(b => b.isbn === isbn);
-    this.setState({ bookFormContent });
-    this.setState({ editing: true });
+    const selectedBook = books.find(b => b.isbn === isbn);
+    this.setState({ selectedBook });
     this.setState({ showEditForm: true });
   };
 
-  editBook = (key, value) => {
-    const bookFormContent = { ...this.state.bookFormContent };
-    if (value) {
-      bookFormContent[key] = value;
-      if (key === "isbn") {
-        this.checkForCollision(value);
-      }
-    } else {
-      delete bookFormContent[key];
-    }
-    this.setState({ bookFormContent });
-  };
-
-  saveBook = () => {
+  saveBook = newBook => {
     const books = this.state.books;
-    const newBook = { ...this.state.bookFormContent };
-    const index = books.findIndex(b => b.isbn === newBook.isbn);
-    if (index >= 0) {
-      books.splice(index, 1, newBook);
+    const i = books.findIndex(b => b.isbn === newBook.isbn);
+    if (i >= 0) {
+      books.splice(i, 1, newBook);
     } else {
       books.push(newBook);
     }
     this.setState({ books });
-    this.setState({ bookFormContent: {} });
-    this.setState({ editing: false });
+    this.setState({ selectedBook: {} });
     this.setState({ showEditForm: false });
   };
 
   deleteBook = isbn => {
     const books = this.state.books;
-    const index = books.findIndex(b => b.isbn === isbn);
-    books.splice(index, 1);
+    const i = books.findIndex(b => b.isbn === isbn);
+    books.splice(i, 1);
     this.setState({ books });
   };
 
@@ -149,18 +131,17 @@ class App extends React.Component {
           loadSampleBooks={this.loadSampleBooks}
           toggleAdminMode={this.toggleAdminMode}
         />
-        {this.state.adminMode && (
-          <BookForm
-            bookFormContent={this.state.bookFormContent}
-            showEditForm={this.state.showEditForm}
-            editing={this.state.editing}
-            isbnCollision={this.state.isbnCollision}
-            createNewBook={this.createNewBook}
-            editBook={this.editBook}
-            saveBook={this.saveBook}
-            toggleModal={this.toggleModal}
-          />
-        )}
+        {this.state.adminMode &&
+          this.state.showEditForm && (
+            <BookForm
+              selectedBook={this.state.selectedBook}
+              isbnCollision={this.state.isbnCollision}
+              checkForCollision={this.checkForCollision}
+              createNewBook={this.createNewBook}
+              saveBook={this.saveBook}
+              toggleModal={this.toggleModal}
+            />
+          )}
       </main>
     );
   }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,6 +6,7 @@ import BookForm from "./BookForm";
 import Footer from "./Footer";
 import initBooks from "../init-books";
 import sampleBooks from "../sample-books";
+import { clean } from "../helpers";
 
 class App extends React.Component {
   state = {
@@ -82,6 +83,7 @@ class App extends React.Component {
 
   saveBook = newBook => {
     const books = this.state.books;
+    clean(newBook);
     const index = books.findIndex(book => book.isbn === newBook.isbn);
     if (index >= 0) {
       books.splice(index, 1, newBook);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -56,14 +56,14 @@ class App extends React.Component {
     if (value) {
       filters.push(name);
     } else {
-      const i = filters.indexOf(name);
-      if (i >= 0) filters.splice(i, 1);
+      const index = filters.indexOf(name);
+      if (index >= 0) filters.splice(index, 1);
     }
     this.setState({ filters });
   };
 
   checkForCollision = isbn => {
-    const isbnList = this.state.books.map(b => b.isbn);
+    const isbnList = this.state.books.map(book => book.isbn);
     const isbnCollision = isbnList.includes(isbn);
     this.setState({ isbnCollision });
   };
@@ -75,16 +75,16 @@ class App extends React.Component {
 
   loadBook = isbn => {
     const books = this.state.books;
-    const selectedBook = books.find(b => b.isbn === isbn);
+    const selectedBook = books.find(book => book.isbn === isbn);
     this.setState({ selectedBook });
     this.setState({ showEditForm: true });
   };
 
   saveBook = newBook => {
     const books = this.state.books;
-    const i = books.findIndex(b => b.isbn === newBook.isbn);
-    if (i >= 0) {
-      books.splice(i, 1, newBook);
+    const index = books.findIndex(book => book.isbn === newBook.isbn);
+    if (index >= 0) {
+      books.splice(index, 1, newBook);
     } else {
       books.push(newBook);
     }
@@ -95,8 +95,8 @@ class App extends React.Component {
 
   deleteBook = isbn => {
     const books = this.state.books;
-    const i = books.findIndex(b => b.isbn === isbn);
-    books.splice(i, 1);
+    const index = books.findIndex(book => book.isbn === isbn);
+    books.splice(index, 1);
     this.setState({ books });
   };
 

--- a/src/components/BookForm.js
+++ b/src/components/BookForm.js
@@ -26,7 +26,19 @@ class BookForm extends React.Component {
   };
 
   state = {
-    book: { ...this.props.selectedBook }
+    book: {
+      title: this.props.selectedBook.title || "",
+      author: this.props.selectedBook.author || "",
+      isbn: this.props.selectedBook.isbn || "",
+      rating: this.props.selectedBook.rating || "",
+      length: this.props.selectedBook.length || "",
+      series: this.props.selectedBook.series || "",
+      textSnippet: this.props.selectedBook.textSnippet || "",
+      source: this.props.selectedBook.source || "",
+      note: this.props.selectedBook.note || "",
+      purchased: this.props.selectedBook.purchased || false,
+      prioritize: this.props.selectedBook.prioritize || false
+    }
   };
 
   handleConfirmSubmit = e => {
@@ -59,7 +71,7 @@ class BookForm extends React.Component {
   };
 
   handleChange = e => {
-    const book = { ...this.state.book };
+    const book = this.state.book;
     const name = e.currentTarget.name;
     const type = e.currentTarget.type;
     let value;
@@ -73,16 +85,12 @@ class BookForm extends React.Component {
     if (name === "isbn") {
       this.props.checkForCollision(value);
     }
-    if (value) {
-      book[name] = value;
-    } else {
-      delete book[name];
-    }
+    book[name] = value;
     this.setState({ book });
   };
 
   render() {
-    const { book } = this.state;
+    const book = this.state.book;
     let handler = this.handleSubmit;
     if (this.props.isbnCollision && !this.props.selectedBook.isbn) {
       handler = this.handleConfirmSubmit;

--- a/src/components/BookForm.js
+++ b/src/components/BookForm.js
@@ -82,7 +82,7 @@ class BookForm extends React.Component {
   };
 
   render() {
-    const { ...book } = this.state.book;
+    const { book } = this.state;
     let handler = this.handleSubmit;
     if (this.props.isbnCollision && !this.props.selectedBook.isbn) {
       handler = this.handleConfirmSubmit;

--- a/src/components/BookForm.js
+++ b/src/components/BookForm.js
@@ -5,7 +5,7 @@ import { confirmAlert } from "react-confirm-alert";
 
 class BookForm extends React.Component {
   static propTypes = {
-    bookFormContent: PropTypes.shape({
+    selectedBook: PropTypes.shape({
       title: PropTypes.string,
       author: PropTypes.string,
       isbn: PropTypes.string,
@@ -18,19 +18,22 @@ class BookForm extends React.Component {
       purchased: PropTypes.bool,
       prioritize: PropTypes.bool
     }).isRequired,
+    checkForCollision: PropTypes.func.isRequired,
     createNewBook: PropTypes.func.isRequired,
-    editBook: PropTypes.func.isRequired,
-    editing: PropTypes.bool.isRequired,
     saveBook: PropTypes.func.isRequired,
-    showEditForm: PropTypes.bool.isRequired,
     toggleModal: PropTypes.func.isRequired,
     isbnCollision: PropTypes.bool.isRequired
+  };
+
+  state = {
+    book: { ...this.props.selectedBook }
   };
 
   handleConfirmSubmit = e => {
     e.preventDefault();
     confirmAlert({
       customUI: ({ onClose }) => {
+        const book = this.state.book;
         const message =
           "You are about to update a book that’s already in the book list. " +
           "Are you sure you want to do that? Pressing Cancel will return you " +
@@ -42,6 +45,7 @@ class BookForm extends React.Component {
             message={message}
             yesButton="Edit Book"
             action={this.props.saveBook}
+            option={book}
           />
         );
       }
@@ -50,10 +54,12 @@ class BookForm extends React.Component {
 
   handleSubmit = e => {
     e.preventDefault();
-    this.props.saveBook();
+    const book = this.state.book;
+    this.props.saveBook(book);
   };
 
   handleChange = e => {
+    const book = { ...this.state.book };
     const name = e.currentTarget.name;
     const type = e.currentTarget.type;
     let value;
@@ -64,19 +70,25 @@ class BookForm extends React.Component {
     } else {
       value = e.currentTarget.value;
     }
-    this.props.editBook(name, value);
+    if (name === "isbn") {
+      this.props.checkForCollision(value);
+    }
+    if (value) {
+      book[name] = value;
+    } else {
+      delete book[name];
+    }
+    this.setState({ book });
   };
 
   render() {
-    const { ...book } = this.props.bookFormContent;
-    let classes = "modal";
-    if (this.props.showEditForm) classes += " is-visible";
+    const { ...book } = this.state.book;
     let handler = this.handleSubmit;
-    if (this.props.isbnCollision && this.props.editing === false) {
+    if (this.props.isbnCollision && !this.props.selectedBook.isbn) {
       handler = this.handleConfirmSubmit;
     }
     return (
-      <div className={classes}>
+      <div className="modal is-visible">
         <form className="form modal-contents" onSubmit={handler}>
           <div className="form-group">
             <label htmlFor="book-title">Title</label>
@@ -86,7 +98,7 @@ class BookForm extends React.Component {
               id="book-title"
               name="title"
               required
-              value={book.title || ""}
+              value={book.title}
               onChange={this.handleChange}
             />
           </div>
@@ -98,7 +110,7 @@ class BookForm extends React.Component {
               id="book-author"
               name="author"
               required
-              value={book.author || ""}
+              value={book.author}
               onChange={this.handleChange}
             />
           </div>
@@ -110,7 +122,7 @@ class BookForm extends React.Component {
               id="book-isbn"
               name="isbn"
               required
-              value={book.isbn || ""}
+              value={book.isbn}
               onChange={this.handleChange}
             />
           </div>
@@ -121,7 +133,7 @@ class BookForm extends React.Component {
               className="form-control"
               id="book-series"
               name="series"
-              value={book.series || ""}
+              value={book.series}
               onChange={this.handleChange}
             />
           </div>
@@ -136,7 +148,7 @@ class BookForm extends React.Component {
               id="book-rating"
               name="rating"
               required
-              value={book.rating || ""}
+              value={book.rating}
               onChange={this.handleChange}
             />
           </div>
@@ -149,7 +161,7 @@ class BookForm extends React.Component {
                 id="book-length"
                 name="length"
                 required
-                value={book.length || ""}
+                value={book.length}
                 onChange={this.handleChange}
               />
               <span className="input-group-append">pages</span>
@@ -162,7 +174,7 @@ class BookForm extends React.Component {
               id="book-textsnippet"
               name="textSnippet"
               rows="3"
-              value={book.textSnippet || ""}
+              value={book.textSnippet}
               onChange={this.handleChange}
             />
             <small className="form-text text-muted">
@@ -178,7 +190,7 @@ class BookForm extends React.Component {
                 className="form-control"
                 id="book-source"
                 name="source"
-                value={book.source || ""}
+                value={book.source}
                 onChange={this.handleChange}
               />
             </span>
@@ -190,7 +202,7 @@ class BookForm extends React.Component {
               id="book-note"
               name="note"
               rows="3"
-              value={book.note || ""}
+              value={book.note}
               onChange={this.handleChange}
             />
             <small className="form-text text-muted">
@@ -203,7 +215,7 @@ class BookForm extends React.Component {
               className="form-check-input"
               id="book-purchased"
               name="purchased"
-              checked={book.purchased || ""}
+              checked={book.purchased}
               onChange={this.handleChange}
             />
             <label className="form-check-label" htmlFor="book-purchased">
@@ -216,7 +228,7 @@ class BookForm extends React.Component {
               className="form-check-input"
               id="book-prioritize"
               name="prioritize"
-              checked={book.prioritize || ""}
+              checked={book.prioritize}
               onChange={this.handleChange}
             />
             <label className="form-check-label" htmlFor="book-prioritize">

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,3 +7,15 @@ export const reverseName = name => {
   }
   return `${firstName} ${lastName}`;
 };
+
+export const clean = object => {
+  for (let propName in object) {
+    if (
+      object[propName] === null ||
+      object[propName] === undefined ||
+      object[propName] === ""
+    ) {
+      delete object[propName];
+    }
+  }
+};


### PR DESCRIPTION
This commit fixes a performance bug that was caused by storing state
for the edit form in App, rather than in BookForm. By moving it, we
avoid a situation where the entire book list was refreshing with each
keystroke(!) and keep things more isolated. Now, BookForm is only
initialized when called for, and it primes its own state with the
contents of App.state.selectedBook, but then tracks its own changes.

Fix #15